### PR TITLE
chore: new action version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@764692186e52cd0f9f6e169bc6d7ac288083420c
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.9.0
     with:
       image-name: milo-os-com
     secrets: inherit
@@ -27,7 +27,7 @@ jobs:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@764692186e52cd0f9f6e169bc6d7ac288083420c
+    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.9.0
     with:
       bundle-name: ghcr.io/datum-cloud/milo-os-com-kustomize
       bundle-path: config


### PR DESCRIPTION
This PR tests the new official version of the custom action "publish-kustomize-bundle" to ensure the correct structure in all tags of the generated OCI artifact