### PR TITLE
chore: add comment for stargazer cache fallback

### DIFF
--- a/src/components/GithubStargazerValue.astro
+++ b/src/components/GithubStargazerValue.astro
@@ -4,6 +4,7 @@ import { Cache } from '@libs/cache';
 const cache = new Cache('.cache');
 
 let starCount = 0;
+// Prefer the cached star count so the component can render without an API call.
 if (cache.has('stargazerCount')) {
   starCount = cache.get<number>('stargazerCount') ?? 0;
 }


### PR DESCRIPTION
Adds a brief inline comment to `GithubStargazerValue.astro` explaining why the component reads from the cache before making an API call.