### PR TITLE
Update references for the move to milo-os

### DIFF
--- a/.github/workflows/.quality.yml
+++ b/.github/workflows/.quality.yml
@@ -92,7 +92,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/datum-cloud/milo-os-com
+          images: ghcr.io/milo-os/milo-os-com
           tags: |
             type=ref,event=pr
             type=ref,event=branch

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
       packages: write
     uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.14.0
     with:
+      registry-organization: milo-os
       image-name: milo-os-com
     secrets: inherit
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,9 +29,9 @@ jobs:
       packages: write
     uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.14.0
     with:
-      bundle-name: ghcr.io/datum-cloud/milo-os-com-kustomize
+      bundle-name: ghcr.io/milo-os/milo-os-com-kustomize
       bundle-path: config
       image-overlays: config/base
-      image-name: ghcr.io/datum-cloud/milo-os-com
+      image-name: ghcr.io/milo-os/milo-os-com
       debug: true
     secrets: inherit

--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: milo-os-com
-          image: ghcr.io/datum-cloud/milo-os-com:latest
+          image: ghcr.io/milo-os/milo-os-com:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 4321


### PR DESCRIPTION
This repo recently moved from [datum-cloud](https://github.com/datum-cloud) to [milo-os](https://github.com/milo-os). Updates internal links and image references to reflect the new home.