### PR TITLE
feat: deploy milo-os.com to Datum Cloud compute as a Unikraft unikernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,10 @@ dist/
 .vercel/
 .cache/
 
+# Unikraft unikernel build cache / artifacts
+.unikraft/
+*.oci
+
 # Playwright
 /test-results/
 /playwright-report/

--- a/Dockerfile.unikraft
+++ b/Dockerfile.unikraft
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+# Builds the rootfs for the milo-os.com Unikraft unikernel (FROM scratch).
+# Entrypoint is set by the Kraftfile cmd.
+
+# amd64 pin: base-compat is x86_64, so the node binary + musl libs must be x86_64
+# (build host may be arm64; BuildKit cross-builds via qemu).
+FROM --platform=linux/amd64 node:22-alpine AS build
+WORKDIR /usr/src
+
+COPY package.json package-lock.json* ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm install \
+      --fetch-retries=8 \
+      --fetch-retry-factor=2 \
+      --fetch-retry-mintimeout=20000 \
+      --fetch-retry-maxtimeout=180000 \
+      --fetch-timeout=600000
+
+COPY . .
+
+# node:22-alpine has no bun; invoke the Astro toolchain directly.
+RUN npx astro check --skip-playwright && npx astro build
+
+# Bundle server.mjs + its deps into one self-contained ESM file. It must live in
+# dist/server/ so the @astrojs/node adapter resolves dist/client as ../client.
+RUN node_modules/.bin/esbuild server.mjs \
+      --bundle \
+      --platform=node \
+      --format=esm \
+      --outfile=dist/server/server.mjs \
+      --external:node:* \
+      --packages=bundle \
+      '--banner:js=import { createRequire as __cr } from "node:module"; const require = __cr(import.meta.url);'
+
+RUN echo "=== ldd node ===" && ldd /usr/local/bin/node || true
+
+FROM scratch
+COPY --from=build /usr/local/bin/node /usr/bin/node
+COPY --from=build /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=build /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=build /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+COPY --from=build /etc/os-release /etc/os-release
+COPY --from=build /usr/src/dist /usr/src/dist
+CMD ["/usr/bin/node", "/usr/src/dist/server/server.mjs"]

--- a/Kraftfile
+++ b/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.7
+name: milo-os-com
+runtime: base-compat:latest
+# rootfs.format omitted: base-compat boots a CPIO initramfs, not erofs.
+rootfs:
+  source: ./Dockerfile.unikraft
+cmd: ["/usr/bin/node", "/usr/src/dist/server/server.mjs"]

--- a/deploy/datum/README.md
+++ b/deploy/datum/README.md
@@ -1,0 +1,79 @@
+# Datum Cloud deployment for milo-os.com
+
+Kustomize program that deploys the milo-os.com website as a Datum Cloud compute
+`Workload` (`compute.datumapis.com/v1alpha`). The Workload runs the Unikraft
+unikernel image and sources the GitHub App credentials from a Kubernetes Secret
+**by reference only**.
+
+```
+deploy/datum/
+  base/
+    kustomization.yaml
+    workload.yaml
+    kustomizeconfig/
+      images.yaml
+  overlays/
+    staging/
+      kustomization.yaml
+  secret.example.yaml
+  README.md
+```
+
+## Prerequisite: the Secret must already exist
+
+This program does **not** create or contain any secret. It expects a Secret
+named `milo-os-com-secrets` to **already exist** in the target project's
+`default` namespace, with keys `APP_ID`, `APP_INSTALLATION_ID`, and
+`APP_PRIVATE_KEY`. The Workload references those keys as environment variables
+via `valueFrom.secretKeyRef`.
+
+Create the Secret from your secret manager (Vault, 1Password, SOPS, External
+Secrets Operator, ...) before deploying. `secret.example.yaml` is a template you
+can fill in — it is documentation only and is intentionally **not** part of any
+kustomization:
+
+```sh
+# fill in real values first — never commit them
+datumctl apply -f deploy/datum/secret.example.yaml
+```
+
+The platform's referenced-data resolver propagates the Secret to the POP cell
+running the Instance; the WorkloadDeployment surfaces a `ReferencedDataReady`
+condition once propagation completes.
+
+## Deploy
+
+Build the overlay and deploy the Workload with `datumctl`:
+
+```sh
+kustomize build deploy/datum/overlays/staging | datumctl compute deploy -f - -y
+```
+
+`compute deploy` watches the rollout and prints live progress until the new
+Instance is ready. Alternatively, apply the overlay declaratively:
+
+```sh
+datumctl apply -k deploy/datum/overlays/staging
+```
+
+Verify the Instance:
+
+```sh
+datumctl compute instances --workload=milo-os-com
+```
+
+## Per-environment knobs (overlay)
+
+Each overlay pins:
+
+- **Image tag** — via the `images:` transformer. The Workload's image lives at
+  the non-standard CRD path `spec/template/spec/runtime/sandbox/containers[]/image`,
+  so `base/kustomizeconfig/images.yaml` registers a FieldSpec teaching the
+  built-in transformer to find it on `kind: Workload`.
+- **`SITE_URL`** — patched per overlay (staging uses `https://www.milo-os.com/`).
+
+## Secrets are not part of this program
+
+By design, no secret values are stored or generated here. There is no
+`secretGenerator` and the Secret is never listed in `resources`. The Workload
+only references an externally-managed Secret by name.

--- a/deploy/datum/base/kustomization.yaml
+++ b/deploy/datum/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: default
+
+resources:
+  - workload.yaml
+
+configurations:
+  - kustomizeconfig/images.yaml

--- a/deploy/datum/base/kustomizeconfig/images.yaml
+++ b/deploy/datum/base/kustomizeconfig/images.yaml
@@ -1,0 +1,3 @@
+images:
+  - path: spec/template/spec/runtime/sandbox/containers[]/image
+    kind: Workload

--- a/deploy/datum/base/workload.yaml
+++ b/deploy/datum/base/workload.yaml
@@ -1,0 +1,50 @@
+apiVersion: compute.datumapis.com/v1alpha
+kind: Workload
+metadata:
+  name: milo-os-com
+spec:
+  template:
+    spec:
+      runtime:
+        resources:
+          instanceType: datumcloud/d1-standard-2
+        sandbox:
+          containers:
+            - name: app
+              image: index.unikraft.io/datum/milo-os-com:slim
+              env:
+                - name: NODE_ENV
+                  value: production
+                - name: PORT
+                  value: "4321"
+                - name: SITE_URL
+                  value: "https://www.milo-os.com/"
+                - name: APP_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: milo-os-com-secrets
+                      key: APP_ID
+                - name: APP_INSTALLATION_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: milo-os-com-secrets
+                      key: APP_INSTALLATION_ID
+                - name: APP_PRIVATE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: milo-os-com-secrets
+                      key: APP_PRIVATE_KEY
+              ports:
+                - name: http
+                  port: 4321
+                  protocol: TCP
+      networkInterfaces:
+        - network:
+            name: default
+  placements:
+    - name: us
+      cityCodes:
+        - DFW
+      scaleSettings:
+        minReplicas: 1
+        instanceManagementPolicy: OrderedReady

--- a/deploy/datum/overlays/staging/kustomization.yaml
+++ b/deploy/datum/overlays/staging/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+images:
+  - name: index.unikraft.io/datum/milo-os-com
+    newTag: slim
+
+patches:
+  - target:
+      kind: Workload
+      name: milo-os-com
+    patch: |
+      - op: replace
+        path: /spec/template/spec/runtime/sandbox/containers/0/env/2/value
+        value: "https://www.milo-os.com/"

--- a/deploy/datum/secret.example.yaml
+++ b/deploy/datum/secret.example.yaml
@@ -1,0 +1,24 @@
+# Template for the milo-os.com Secret — placeholders only, do not commit real values.
+# Create it in the project control plane, in the Workload's namespace (default).
+# The Workload references these keys as env vars via secretKeyRef.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: milo-os-com-secrets
+  namespace: default
+type: Opaque
+stringData:
+  # GitHub App credentials for live roadmap/changelog data.
+  APP_ID: "REPLACE_WITH_GITHUB_APP_ID"
+  APP_INSTALLATION_ID: "REPLACE_WITH_GITHUB_APP_INSTALLATION_ID"
+  APP_PRIVATE_KEY: |
+    -----BEGIN RSA PRIVATE KEY-----
+    REPLACE_WITH_GITHUB_APP_PRIVATE_KEY_PEM_BODY
+    -----END RSA PRIVATE KEY-----
+
+  # Optional: Postgres for roadmap voting (omitted in staging; degrades gracefully).
+  # POSTGRES_USER: "REPLACE_WITH_POSTGRES_USER"
+  # POSTGRES_PASSWORD: "REPLACE_WITH_POSTGRES_PASSWORD"
+  # POSTGRES_HOST: "REPLACE_WITH_POSTGRES_HOST"
+  # POSTGRES_PORT: "5432"
+  # POSTGRES_DB: "REPLACE_WITH_POSTGRES_DB"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/node": "^25.6.0",
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.59.1",
+    "esbuild": "^0.27.7",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-astro": "^1.7.0",

--- a/server.mjs
+++ b/server.mjs
@@ -10,7 +10,14 @@ const __dirname = dirname(__filename);
 
 const PORT = process.env.PORT || 4321;
 const HOST = process.env.HOST || '0.0.0.0';
-const CLIENT_DIR = join(__dirname, 'dist', 'client');
+
+// Client dir: ./dist/client in dev; ../client in the bundled unikernel layout
+// (esbuild bundle lives in dist/server/). CLIENT_DIR env overrides.
+const CLIENT_DIR =
+  process.env.CLIENT_DIR ||
+  (existsSync(join(__dirname, 'dist', 'client'))
+    ? join(__dirname, 'dist', 'client')
+    : join(__dirname, '..', 'client'));
 
 const CONTENT_TYPES = {
   '.html': 'text/html; charset=utf-8',


### PR DESCRIPTION
## Summary

Adds the ability to deploy **milo-os.com** to **Datum Cloud's compute platform**, running the site as a Unikraft unikernel. The Astro server is packaged into a bootable unikernel image and deployed as a `compute.datumapis.com/v1alpha` `Workload`.

## What's included

- **Unikernel build** — [the unikernel Dockerfile](https://github.com/milo-os/milo-os.com/blob/feat/datum-compute-deploy/Dockerfile.unikraft) and [Kraftfile](https://github.com/milo-os/milo-os.com/blob/feat/datum-compute-deploy/Kraftfile) package the Astro SSR server into a bootable Unikraft unikernel image (esbuild-bundled entrypoint + Node binary on a minimal scratch rootfs).
- **Deploy program** — a [Kustomize program](https://github.com/milo-os/milo-os.com/tree/feat/datum-compute-deploy/deploy/datum) (base + staging overlay) that deploys the `Workload`, pinning the image tag and per-environment `SITE_URL`.
- **App changes** — bundled-asset path detection in [the server entrypoint](https://github.com/milo-os/milo-os.com/blob/feat/datum-compute-deploy/server.mjs) so the Astro server runs inside the unikernel layout, plus `esbuild` as a build-time devDependency.

## Secrets

GitHub App credentials are **referenced by name only** (`secretKeyRef` → `milo-os-com-secrets`) and are **not** included in this PR. The Secret is expected to already exist in the target project's `default` namespace; [an example Secret template](https://github.com/milo-os/milo-os.com/blob/feat/datum-compute-deploy/deploy/datum/secret.example.yaml) is provided with placeholder values only.

## Deploy

```sh
kustomize build deploy/datum/overlays/staging | datumctl compute deploy -f - -y
# or, declaratively: datumctl apply -k deploy/datum/overlays/staging
```

See [the deploy guide](https://github.com/milo-os/milo-os.com/blob/feat/datum-compute-deploy/deploy/datum/README.md) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

